### PR TITLE
Feat: The specific_args can support a 'comparator' entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ dir_content_diff.assert_equal_trees(
 
 Each comparator has different arguments that are detailed in the documentation.
 
+It's also possible to specify a arbitrary comparator for a specific file:
+
+```python
+specific_args = {
+    "sub_dir_1/sub_file_1.a": {
+        "comparator": dir_content_diff.JsonComparator(),
+        "tolerance": 0.5,
+    }
+}
+```
+
 
 ### Export formatted data
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -706,6 +706,16 @@ class TestEqualTrees:
 
         assert res == {}
 
+    def test_specific_comparator(self, ref_tree, res_tree_equal):
+        """Test specific args."""
+        specific_args = {
+            "file.yaml": {"args": [None, None, None, False, 0, False]},
+            "file.json": {"comparator": dir_content_diff.DefaultComparator()},
+        }
+        res = compare_trees(ref_tree, res_tree_equal, specific_args=specific_args)
+
+        assert res == {}
+
 
 class TestDiffTrees:
     """Tests that should return differences."""


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
<!-- The title should have the following form: 'Type: Subject' with 'type' in [Build,Chore,CI,Reprecate,Docs,Feat,Fix,Perf,Refactor,Revert,Style,Test] -->

### Description
For a specific file it can be useful to specify a specific comparator. Now it's possible using the following format:
```python
        specific_args = {
            "the_file": {"comparator": dir_content_diff.DefaultComparator()},
        }
```

### Checklist
<!-- Go over following points. Check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once). -->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [x] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [x] Please include tests that cover every lines of the new/updated feature.
	- [x] Please update the documentation to describe the new/updated feature.

<!-- **Have a nice day!** -->
