### PR TITLE
Feat: Add parameters for load and save methods of base comparators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.5.0
+    rev: v9.13.0
     hooks:
         - id: commitlint
           stages:

--- a/dir_content_diff/base_comparators.py
+++ b/dir_content_diff/base_comparators.py
@@ -406,16 +406,16 @@ class JsonComparator(DictComparator):
     This comparator is based on the :class:`DictComparator` and uses the same parameters.
     """
 
-    def load(self, path):
+    def load(self, path, **kwargs):
         """Open a JSON file."""
         with open(path) as file:  # pylint: disable=unspecified-encoding
-            data = json.load(file)
+            data = json.load(file, **kwargs)
         return data
 
-    def save(self, data, path):
+    def save(self, data, path, **kwargs):
         """Save formatted data into a JSON file."""
         with open(path, "w", encoding="utf-8") as file:
-            json.dump(data, file)
+            json.dump(data, file, **kwargs)
 
 
 class YamlComparator(DictComparator):
@@ -424,16 +424,16 @@ class YamlComparator(DictComparator):
     This comparator is based on the :class:`DictComparator` and uses the same parameters.
     """
 
-    def load(self, path):
+    def load(self, path, **kwargs):
         """Open a YAML file."""
         with open(path) as file:  # pylint: disable=unspecified-encoding
-            data = yaml.full_load(file)
+            data = yaml.full_load(file, **kwargs)
         return data
 
-    def save(self, data, path):
+    def save(self, data, path, **kwargs):
         """Save formatted data into a YAML file."""
         with open(path, "w", encoding="utf-8") as file:
-            yaml.dump(data, file)
+            yaml.dump(data, file, **kwargs)
 
 
 class XmlComparator(DictComparator):
@@ -468,10 +468,10 @@ class XmlComparator(DictComparator):
             data = self.xmltodict(file.read())
         return data
 
-    def save(self, data, path):
+    def save(self, data, path, root=False, **kwargs):
         """Save formatted data into a XML file."""
         with open(path, "w", encoding="utf-8") as file:
-            file.write(dicttoxml(data["root"]).decode())
+            file.write(dicttoxml(data, root=root, **kwargs).decode())
 
     @staticmethod
     def _cast_from_attribute(text, attr):
@@ -544,10 +544,10 @@ class IniComparator(DictComparator):
         data.read(path)
         return self.configparser_to_dict(data)
 
-    def save(self, data, path):
+    def save(self, data, path, **kwargs):
         """Save formatted data into a INI file."""
         with open(path, "w", encoding="utf-8") as file:
-            self.dict_to_configparser(data).write(file)
+            self.dict_to_configparser(data, **kwargs).write(file)
 
     @staticmethod
     def configparser_to_dict(config):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -410,8 +410,34 @@ class TestBaseComparator:
         assert kwargs_msg in no_report_diff_default
         assert no_report_diff_default.replace(kwargs_msg, "") == diff
 
+    @staticmethod
+    def _test_load_save(tmp_path, comparator):
+        """Test load and save capabilities of the given comparator."""
+        initial_data = {
+            "a": {
+                "b": 1,
+                "c": [1, 2, 3],
+                "d": {
+                    "test_str": "a str",
+                    "test_int": 999,
+                },
+            }
+        }
+
+        initial_file = tmp_path / "initial_file.json"
+        comparator.save(initial_data, initial_file)
+
+        loaded_data = comparator.load(initial_file)
+
+        assert loaded_data == initial_data
+
     class TestJsonComparator:
         """Test the JSON comparator."""
+
+        def test_load_save(self, tmp_path):
+            """Test load and save capabilities of the comparator."""
+            comparator = dir_content_diff.JsonComparator()
+            TestBaseComparator._test_load_save(tmp_path, comparator)
 
         def test_format_data(self):
             """Test data formatting."""
@@ -489,6 +515,11 @@ class TestBaseComparator:
 
     class TestXmlComparator:
         """Test the XML comparator."""
+
+        def test_load_save(self, tmp_path):
+            """Test load and save capabilities of the comparator."""
+            comparator = dir_content_diff.XmlComparator()
+            TestBaseComparator._test_load_save(tmp_path, comparator)
 
         def test_xmltodict(self):
             """Test all types of the xmltodict auto cast feature."""
@@ -573,6 +604,11 @@ class TestBaseComparator:
 
     class TestIniComparator:
         """Test the INI comparator."""
+
+        def test_load_save(self, tmp_path):
+            """Test load and save capabilities of the comparator."""
+            comparator = dir_content_diff.IniComparator()
+            TestBaseComparator._test_load_save(tmp_path, comparator)
 
         def test_initodict(self, ref_tree):
             """Test conversion of INI files into dict."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -411,7 +411,7 @@ class TestBaseComparator:
         assert no_report_diff_default.replace(kwargs_msg, "") == diff
 
     @staticmethod
-    def _test_load_save(tmp_path, comparator):
+    def common_test_load_save(tmp_path, comparator):
         """Test load and save capabilities of the given comparator."""
         initial_data = {
             "a": {
@@ -437,7 +437,7 @@ class TestBaseComparator:
         def test_load_save(self, tmp_path):
             """Test load and save capabilities of the comparator."""
             comparator = dir_content_diff.JsonComparator()
-            TestBaseComparator._test_load_save(tmp_path, comparator)
+            TestBaseComparator.common_test_load_save(tmp_path, comparator)
 
         def test_format_data(self):
             """Test data formatting."""
@@ -519,7 +519,7 @@ class TestBaseComparator:
         def test_load_save(self, tmp_path):
             """Test load and save capabilities of the comparator."""
             comparator = dir_content_diff.XmlComparator()
-            TestBaseComparator._test_load_save(tmp_path, comparator)
+            TestBaseComparator.common_test_load_save(tmp_path, comparator)
 
         def test_xmltodict(self):
             """Test all types of the xmltodict auto cast feature."""
@@ -608,7 +608,7 @@ class TestBaseComparator:
         def test_load_save(self, tmp_path):
             """Test load and save capabilities of the comparator."""
             comparator = dir_content_diff.IniComparator()
-            TestBaseComparator._test_load_save(tmp_path, comparator)
+            TestBaseComparator.common_test_load_save(tmp_path, comparator)
 
         def test_initodict(self, ref_tree):
             """Test conversion of INI files into dict."""


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
<!-- The title should have the following form: 'Type: Subject' with 'type' in [Build,Chore,CI,Reprecate,Docs,Feat,Fix,Perf,Refactor,Revert,Style,Test] -->

### Description
Add some parameters to `load()` and `save()` methods of several base comparators and set `root=False` by default for `XmlComparator.save()`

### Checklist
<!-- Go over following points. Check them with an `x` if they do apply (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once). -->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [x] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [x] Please include tests that cover every lines of the new/updated feature.
	- [x] Please update the documentation to describe the new/updated feature.

<!-- **Have a nice day!** -->
